### PR TITLE
Feature/4 unit of work di

### DIFF
--- a/docs/dev_notes_4
+++ b/docs/dev_notes_4
@@ -1,0 +1,9 @@
+Problem statement:
+- presently our Service layer is dependent on Session and as well as abstract repository and hance is coupled with the data layer
+    -   allocate(order_line: OrderLine, repository: AbstractRepository, session):
+
+- because of this we have to instantiate a session from our Flaks API module and then pass it to the service along with the repository
+Solution:
+- we create another layer of abstraction called unit of work which will manage session creation and returning to us (service) a repository object thus collaborating with the Repository
+- we make use of unit of work design pattern to decouple our service layer from the data layer.
+    - which means neither the service layer nor the API layer directly communicates with the datalayer.

--- a/docs/dev_notes_4
+++ b/docs/dev_notes_4
@@ -7,3 +7,9 @@ Solution:
 - we create another layer of abstraction called unit of work which will manage session creation and returning to us (service) a repository object thus collaborating with the Repository
 - we make use of unit of work design pattern to decouple our service layer from the data layer.
     - which means neither the service layer nor the API layer directly communicates with the datalayer.
+
+Approach:
+    -   We define a class abstract class AbstractBatchUnitOfWork.
+    -   Define batches (class var), which will give us access to the batches repository.
+    -   This implementation is to be used with a context manager (with) hence we define dunder `enter` and `exit` methods as well.
+    -   `rollback` and `commit` methods are also implemented.

--- a/src/adapters/repository.py
+++ b/src/adapters/repository.py
@@ -11,11 +11,11 @@ UPDATES:
 
 class AbstractRepository(abc.ABC):
     @abc.abstractmethod
-    def add(self, batch: Batch):
+    def add(self, obj):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get(self, reference) -> Batch:
+    def get(self, reference):
         raise NotImplementedError
 
 

--- a/src/service_layer/services.py
+++ b/src/service_layer/services.py
@@ -1,4 +1,5 @@
-from typing import List
+from typing import List, Optional
+from datetime import date
 from domain.models.batch import Batch
 from domain.models.order_line import OrderLine
 from domain.models.batch import allocate as allocate_line
@@ -19,6 +20,25 @@ def is_valid_sku(sku, batches: List[Batch]):
         return True
     else:
         return False
+
+
+def insert_batch(repo: AbstractRepository, session, reference: str, sku: str, quantity: int, eta: Optional[date]):
+    '''
+    :param repo:
+    :param session:
+    :param reference:
+    :param sku:
+    :param quantity:
+    :param eta:
+    :return:
+    '''
+    try:
+        repo.add(Batch(reference=reference, sku=sku, quantity=quantity, eta=eta))
+        session.commit()
+        return True
+    except Exception as e:
+        print("Error :" + e)
+        print("str ERROR:" + str(e))
 
 
 def allocate(order_line: OrderLine, repository: AbstractRepository, session):

--- a/src/service_layer/services.py
+++ b/src/service_layer/services.py
@@ -4,6 +4,7 @@ from domain.models.batch import Batch
 from domain.models.order_line import OrderLine
 from domain.models.batch import allocate as allocate_line
 from adapters.repository import AbstractRepository
+from service_layer.unit_of_work import AbstractBatchUnitOfWork
 
 '''
 UPDATES:
@@ -22,20 +23,22 @@ def is_valid_sku(sku, batches: List[Batch]):
         return False
 
 
-def insert_batch(repo: AbstractRepository, session, reference: str, sku: str, quantity: int, eta: Optional[date]):
+def insert_batch(batch_aow: AbstractBatchUnitOfWork, reference: str, sku: str, quantity: int, eta: Optional[date]):
     '''
-    :param repo:
-    :param session:
+    :param batch_aow: batch unit  of work object
     :param reference:
     :param sku:
     :param quantity:
     :param eta:
-    :return:
+    :return: boolean True: inserted, False : didn't insert
     '''
     try:
-        repo.add(Batch(reference=reference, sku=sku, quantity=quantity, eta=eta))
-        session.commit()
+        with batch_aow:
+            batch_aow.batches.add(Batch(reference=reference, sku=sku, quantity=quantity, eta=eta))
+            batch_aow.commit()
+
         return True
+
     except Exception as e:
         print("Error :" + e)
         print("str ERROR:" + str(e))

--- a/src/service_layer/services.py
+++ b/src/service_layer/services.py
@@ -45,6 +45,13 @@ def insert_batch(batch_aow: AbstractBatchUnitOfWork, reference: str, sku: str, q
 
 
 def allocate(order_line: OrderLine, repository: AbstractRepository, session):
+    """
+    Service layer method to allocate a valid order line to a particular batch
+    :param order_line:
+    :param repository: batch repository object
+    :param session: database session object
+    :return:
+    """
     if not is_valid_sku(order_line.sku, repository.list()):
         raise InvalidSkuException(f'Invalid sku : {order_line.sku}')
 
@@ -58,6 +65,7 @@ def allocate(order_line: OrderLine, repository: AbstractRepository, session):
 def deallocate(order_id: str, batch_ref: str, batch_repository: AbstractRepository, order_line_repo: AbstractRepository,
                session):
     '''
+    deallocate method to remove an allocated line from a batch
     :param order_id:
     :param batch_ref:
     :param batch_repository: batch repository object to fetch necessary batch from DB

--- a/src/service_layer/unit_of_work.py
+++ b/src/service_layer/unit_of_work.py
@@ -1,0 +1,62 @@
+import abc
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import config
+from adapters import repository
+
+'''
+UPDATES:
+    -   The principle is 1 Unit of work should encompass all our repository objects. 
+        But if our repository transactions are mostly executed in Silos then we may choose to define multiple UOW class 
+        as per our requirements.
+        Currently I am following the second approach.
+     
+'''
+
+
+# TODO - maybe define a separate Abstract base class which has the general methods
+#  and that is inherited by our AOW repo specific classes if I am set on 1 AOW to 1 Repo approach
+class AbstractBatchUnitOfWork(abc.ABC):
+    batches: repository.AbstractRepository
+
+    def __exit__(self, *args):
+        self.rollback()
+
+    @abc.abstractmethod
+    def commit(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def rollback(self):
+        raise NotImplementedError
+
+    def __enter__(self):
+        return self
+
+
+DEFAULT_SESSION_FACTORY = sessionmaker(bind=create_engine(
+    config.get_db_url(),
+))
+
+
+class BatchRepoUnitOfWork(AbstractBatchUnitOfWork):
+
+    def __init__(self, session_factory=DEFAULT_SESSION_FACTORY):
+        self._session_factory = session_factory
+
+    def __enter__(self):
+        self.session = self._session_factory()
+        self.batches = repository.BatchRepository(self.session)
+        return super().__enter__()
+
+    def __exit__(self, *args):
+        super().__exit__(*args)
+        self.session.close()
+
+    def commit(self):
+        self.session.commit()
+
+    def rollback(self):
+        self.session.rollback()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,8 +24,8 @@ Updates:
 def session_factory():
     engine = create_engine(config.get_db_url())
     mapper_registry.metadata.create_all(engine)
-    start_mappers()
-    session = sessionmaker(bind=engine)()
+    # start_mappers()
+    session = sessionmaker(bind=engine)
     yield session
     clear_mappers()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,13 +21,18 @@ Updates:
 
 
 @pytest.fixture(scope="session")
-def session():
+def session_factory():
     engine = create_engine(config.get_db_url())
     mapper_registry.metadata.create_all(engine)
-    # start_mappers()
+    start_mappers()
     session = sessionmaker(bind=engine)()
     yield session
     clear_mappers()
+
+
+@pytest.fixture(scope="session")
+def session():
+    return session_factory()
 
 
 @pytest.fixture()
@@ -70,7 +75,7 @@ def add_batch_and_allocations(session):
     order_lines_added = set()
     batch_added = set()
 
-    def _add_batch_and_allocate_lines(batch: Dict, lines: List, unallocated_order_id =''):
+    def _add_batch_and_allocate_lines(batch: Dict, lines: List, unallocated_order_id=''):
         session.execute(text('insert into batches (reference, sku, quantity, eta) values'
                              f'("{batch["reference"]}","{batch["sku"]}",{batch["quantity"]},"{batch["eta"]}")'))
 
@@ -86,11 +91,11 @@ def add_batch_and_allocations(session):
         order_line_ids = []
         for order_id in order_lines_added:
             if order_id != unallocated_order_id:
-                order_line_ids.append(list(session.execute(text('SELECT id FROM order_lines WHERE order_id = :order_id'),
-                                                       {'order_id': order_id}))[0][0])
+                order_line_ids.append(
+                    list(session.execute(text('SELECT id FROM order_lines WHERE order_id = :order_id'),
+                                         {'order_id': order_id}))[0][0])
 
         for line_id in order_line_ids:
-
             session.execute(text('insert into allocations (batch_id, order_line_id) values'
                                  f'({batch_id},{line_id})'))
         session.commit()
@@ -100,7 +105,7 @@ def add_batch_and_allocations(session):
     for batch_id in batch_added:
         session.execute(
             text("DELETE FROM allocations WHERE batch_id=:batch_id"),
-            dict(batch_id= batch_id),
+            dict(batch_id=batch_id),
         )
         session.execute(
             text("DELETE FROM batches WHERE id=:batch_id"), dict(batch_id=batch_id),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,17 +22,25 @@ Updates:
 
 @pytest.fixture(scope="session")
 def session_factory():
-    engine = create_engine(config.get_db_url())
-    mapper_registry.metadata.create_all(engine)
+    session = get_session_obj()
     # start_mappers()
-    session = sessionmaker(bind=engine)
     yield session
     clear_mappers()
 
 
 @pytest.fixture(scope="session")
 def session():
-    return session_factory()
+    session = get_session_obj()
+    # start_mappers()
+    yield session()
+    clear_mappers()
+
+
+def get_session_obj():
+    engine = create_engine(config.get_db_url())
+    mapper_registry.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)
+    return session
 
 
 @pytest.fixture()

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -2,13 +2,13 @@ import pytest
 from sqlalchemy import text
 
 from adapters.repository import BatchRepository, OrderLineRepository
-from domain.models.batch import Batch, OrderLine
+from domain.models.batch import Batch
 from domain.models.order_line import OrderLine
 from datetime import datetime, timedelta
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session
 
 
-def insert_batch_record(session: sessionmaker, batch_ref: str):
+def insert_batch_record(session: Session, batch_ref: str):
     session.execute(text('insert into batches (reference, sku, quantity) values'
                          f'("{batch_ref}","chair-1",50)'))
     session.commit()
@@ -95,7 +95,7 @@ def test_order_line_can_be_de_allocated_from_batches(session):
     batch_obj = batch_session.get('batch-b')
     batch_obj.deallocate(OrderLine(sku="chair-1", quantity=3, order_id="deallocated"))
 
-    session.commit()    # committing the session to see if updating repo object reflects the change in DB or not
+    session.commit()  # committing the session to see if updating repo object reflects the change in DB or not
 
     batch_session = BatchRepository(session)
     batch_obj = batch_session.get('batch-b')

--- a/tests/integration/test_uow.py
+++ b/tests/integration/test_uow.py
@@ -1,0 +1,30 @@
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+from service_layer.unit_of_work import SqlAlchemyBatchUnitOfWork
+
+def insert_batch_in_db(session: Session, reference, sku, quantity, eta):
+    session.execute(text('INSERT INTO batches (reference, sku, _purchased_quantity, eta)'
+                         ' VALUES (:ref, :sku, :qty, :eta)'), dict(ref=reference, sku=sku, qty=quantity, eta=eta))
+    session.commit()
+
+
+def get_allocated_batch_ref(session: Session, orderid, sku):
+    [[order_line_id]] = session.execute(text('SELECT id FROM order_lines WHERE orderid=:orderid AND sku=:sku'),
+                                      dict(orderid=orderid,
+                                           sku=sku)
+                                      )
+    [[batch_ref]] = session.execute(
+        text('SELECT b.reference FROM allocations JOIN batches AS b ON batch_id = b.id'
+             ' WHERE order_line_id=:order_line_id'),
+        dict(order_line_id=order_line_id)
+    )
+    return batch_ref
+
+
+def test_uow_can_retrieve_a_batch_and_allocate_to_it(session_factory):
+    session = session_factory()
+    insert_batch_in_db(session, 'b1', 'workbench', 100, None)
+
+    with SqlAlchemyBatchUnitOfWork() as uow:
+        batches = uow.getBatches()
+        batches.allocate()

--- a/tests/integration/test_uow.py
+++ b/tests/integration/test_uow.py
@@ -1,18 +1,21 @@
 from sqlalchemy import text
 from sqlalchemy.orm import Session
-from service_layer.unit_of_work import SqlAlchemyBatchUnitOfWork
+
+from domain.models.order_line import OrderLine
+from service_layer.unit_of_work import BatchRepoUnitOfWork
+
 
 def insert_batch_in_db(session: Session, reference, sku, quantity, eta):
-    session.execute(text('INSERT INTO batches (reference, sku, _purchased_quantity, eta)'
+    session.execute(text('INSERT INTO batches (reference, sku, quantity, eta)'
                          ' VALUES (:ref, :sku, :qty, :eta)'), dict(ref=reference, sku=sku, qty=quantity, eta=eta))
     session.commit()
 
 
 def get_allocated_batch_ref(session: Session, orderid, sku):
-    [[order_line_id]] = session.execute(text('SELECT id FROM order_lines WHERE orderid=:orderid AND sku=:sku'),
-                                      dict(orderid=orderid,
-                                           sku=sku)
-                                      )
+    [[order_line_id]] = session.execute(text('SELECT id FROM order_lines WHERE order_id=:orderid AND sku=:sku'),
+                                        dict(orderid=orderid,
+                                             sku=sku)
+                                        )
     [[batch_ref]] = session.execute(
         text('SELECT b.reference FROM allocations JOIN batches AS b ON batch_id = b.id'
              ' WHERE order_line_id=:order_line_id'),
@@ -25,6 +28,11 @@ def test_uow_can_retrieve_a_batch_and_allocate_to_it(session_factory):
     session = session_factory()
     insert_batch_in_db(session, 'b1', 'workbench', 100, None)
 
-    with SqlAlchemyBatchUnitOfWork() as uow:
-        batches = uow.getBatches()
-        batches.allocate()
+    with BatchRepoUnitOfWork(session_factory) as uow:
+        batch = uow.batches.get('b1')
+        batch.allocate(OrderLine(order_id='44', sku='workbench', quantity=5))
+        uow.commit()
+
+    batch_ref = get_allocated_batch_ref(session, '44', 'workbench')
+
+    assert batch_ref == 'b1'

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -3,7 +3,7 @@ import pytest
 from domain.models.batch import Batch
 from domain.models.order_line import OrderLine
 from adapters.repository import AbstractRepository
-from service_layer.services import allocate, InvalidSkuException, deallocate
+from service_layer.services import allocate, InvalidSkuException, deallocate, insert_batch
 
 
 class FakeBatchRepository(AbstractRepository):
@@ -96,4 +96,20 @@ def test_service_commits_changes_on_successful_allocation():
 
     session = FakeSession()
     result = allocate(order_line, repo, session)
-    assert session.committed == True
+    assert session.committed
+
+
+def test_service_can_insert_a_batch_on_valid_request():
+    batch_attrs = {"reference": "b_a", "sku": "green-lamp", "quantity": 10, "eta": None}
+
+    repo_batch = FakeBatchRepository([])
+
+    session = FakeSession()
+
+    status = insert_batch(repo_batch, session, **batch_attrs)
+
+    assert status
+    assert repo_batch.get(batch_attrs['reference']) == Batch(reference=batch_attrs['reference'], sku=batch_attrs['sku'],
+                                                             quantity=batch_attrs['quantity'], eta=batch_attrs['eta'])
+    assert session.committed
+

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -50,7 +50,7 @@ class FakeSession():
 class FakeBatchesUnitOfWork(AbstractBatchUnitOfWork):
 
     def __init__(self):
-        self.batch_repo = FakeBatchRepository([])
+        self.batches = FakeBatchRepository([])
         self.committed = False
 
     def commit(self):
@@ -120,8 +120,8 @@ def test_service_can_insert_a_batch_on_valid_request():
     status = insert_batch(aow, **batch_attrs)
 
     assert status
-    assert aow.batch_repo.get(batch_attrs['reference']) == Batch(reference=batch_attrs['reference'],
-                                                                 sku=batch_attrs['sku'],
-                                                                 quantity=batch_attrs['quantity'],
-                                                                 eta=batch_attrs['eta'])
+    assert aow.batches.get(batch_attrs['reference']) == Batch(reference=batch_attrs['reference'],
+                                                              sku=batch_attrs['sku'],
+                                                              quantity=batch_attrs['quantity'],
+                                                              eta=batch_attrs['eta'])
     assert aow.committed


### PR DESCRIPTION
Problem statement:
- presently our Service layer is dependent on Session and as well as abstract repository and hance is coupled with the data layer
    -   allocate(order_line: OrderLine, repository: AbstractRepository, session):

- because of this we have to instantiate a session from our Flaks API module and then pass it to the service along with the repository
Solution:
- we create another layer of abstraction called unit of work which will manage session creation and returning to us (service) a repository object thus collaborating with the Repository
- we make use of unit of work design pattern to decouple our service layer from the data layer.
    - which means neither the service layer nor the API layer directly communicates with the datalayer.

Approach:
    -   We define a class abstract class AbstractBatchUnitOfWork.
    -   Define batches (class var), which will give us access to the batches repository.
    -   This implementation is to be used with a context manager (with) hence we define dunder `enter` and `exit` methods as well.
    -   `rollback` and `commit` methods are also implemented.
